### PR TITLE
Use Apache CouchDB mirrors for dependencies

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -3,9 +3,9 @@ IsRebar3 = erlang:function_exported(rebar3, main, 1),
 
 Rebar2Deps =
   [
-   {local, ".*", {git, "https://github.com/sile/local.git", {tag, "0.2.1"}}},
-   {passage, ".*", {git, "https://github.com/sile/passage.git", {tag, "0.2.6"}}},
-   {thrift_protocol, ".*", {git, "https://github.com/sile/thrift_protocol.git", {tag, "0.1.5"}}}
+   {local, ".*", {git, "https://github.com/apache/couchdb-local.git", {tag, "0.2.1"}}},
+   {passage, ".*", {git, "https://github.com/apache/couchdb-passage.git", {tag, "0.2.6"}}},
+   {thrift_protocol, ".*", {git, "https://github.com/apache/couchdb-thrift-protocol.git", {tag, "0.1.5"}}}
   ],
 
 case IsRebar3 of


### PR DESCRIPTION
This PR is to update `thrift_protocol` from `0.1.3` to `0.1.5` and jaeger_passage itself to `0.1.14`.

# `couchdb-0.1.14` branch is created as follows

```
git remote add upstream git@github.com:sile/jaeger_passage.git
git checkout master
git pull --rebase upstream master
git fetch -t upstream
git push origin master
git push origin 0.1.14
checkout -b couchdb-0.1.14
git push origin couchdb-0.1.14
```

# difference between `CouchDB-0.1.13-1`

```
git diff CouchDB-0.1.13-1 rebar*
diff --git a/rebar.config.script b/rebar.config.script
index 20f0f17..56e94b9 100644
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -5,7 +5,7 @@ Rebar2Deps =
   [
    {local, ".*", {git, "https://github.com/apache/couchdb-local.git", {tag, "0.2.1"}}},
    {passage, ".*", {git, "https://github.com/apache/couchdb-passage.git", {tag, "0.2.6"}}},
-   {thrift_protocol, ".*", {git, "https://github.com/apache/couchdb-thrift-protocol.git", {tag, "0.1.3"}}}
+   {thrift_protocol, ".*", {git, "https://github.com/apache/couchdb-thrift-protocol.git", {tag, "0.1.5"}}}
   ],

 case IsRebar3 of
diff --git a/rebar.lock b/rebar.lock
index c9ba4ec..9d5110a 100644
--- a/rebar.lock
+++ b/rebar.lock
@@ -1,10 +1,10 @@
 {"1.1.0",
 [{<<"local">>,{pkg,<<"local">>,<<"0.2.1">>},0},
  {<<"passage">>,{pkg,<<"passage">>,<<"0.2.6">>},0},
- {<<"thrift_protocol">>,{pkg,<<"thrift_protocol">>,<<"0.1.3">>},0}]}.
+ {<<"thrift_protocol">>,{pkg,<<"thrift_protocol">>,<<"0.1.5">>},0}]}.
 [
 {pkg_hash,[
  {<<"local">>, <<"F82483CD6DB6A39B0E4C59B37C2FCCCF5B96D90A746AFC3D79A81D31E3D40963">>},
  {<<"passage">>, <<"7B0A6F0A6806B056DC3323A6A0243503642E6425F45E33B87277EA0BE88BD130">>},
- {<<"thrift_protocol">>, <<"CDD0C06BFC235159D789353CBB4F01F9FF04592F30329CB3DF2C77E28D92CCC0">>}]}
+ {<<"thrift_protocol">>, <<"300DB7CA06BED397406A4680AD3DD3A0212AC7BEABDC81FA03C3C3DADEA13673">>}]}
 ].
```