### PR TITLE
Use Apache CouchDB mirrors for dependencies

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -3,9 +3,9 @@ IsRebar3 = erlang:function_exported(rebar3, main, 1),
 
 Rebar2Deps =
   [
-   {local, ".*", {git, "https://github.com/sile/local.git", {tag, "0.2.1"}}},
-   {passage, ".*", {git, "https://github.com/sile/passage.git", {tag, "0.2.6"}}},
-   {thrift_protocol, ".*", {git, "https://github.com/sile/thrift_protocol.git", {tag, "0.1.5"}}}
+   {local, ".*", {git, "https://github.com/apache/couchdb-local.git", {tag, "0.2.1"}}},
+   {passage, ".*", {git, "https://github.com/apache/couchdb-passage.git", {tag, "0.2.6"}}},
+   {thrift_protocol, ".*", {git, "https://github.com/apache/couchdb-thrift-protocol.git", {tag, "0.1.5"}}}
   ],
 
 case IsRebar3 of


### PR DESCRIPTION
This PR is to update thrift_protocol from 0.1.3 to 0.1.5 and jaeger_passage itself to 0.1.14.