### PR TITLE
Allow compiling on Erlang 23

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,12 @@ language: erlang
 
 os: linux
 otp_release:
+  - 23.0
   - 22.0
   - 21.0
   - 20.0
-  - 19.3
-  - 18.3
+
+
 
 install:
   - sudo pip install codecov

--- a/src/jaeger_passage_span_context.erl
+++ b/src/jaeger_passage_span_context.erl
@@ -16,6 +16,13 @@
 
 -include("constants.hrl").
 
+
+% Update after moving to 21+ to use uri_string
+-ifdef(OTP_RELEASE).
+-compile({nowarn_deprecated_function, {http_uri, decode, 1}}).
+-compile({nowarn_deprecated_function, {http_uri, encode, 1}}).
+-endif.
+
 %%------------------------------------------------------------------------------
 %% Exported API
 %%------------------------------------------------------------------------------


### PR DESCRIPTION
`http_uri` module will be removed in Erlang 25. There is no obvious replacement in `uri_string` so for now just ignore the deprecation warning.